### PR TITLE
:sparkles: Feat: 회원가입요청 페이지 레이아웃 구성, 컴포넌트 동작 구현, 임시 데이터 연결

### DIFF
--- a/public/daseul/requests.json
+++ b/public/daseul/requests.json
@@ -1,0 +1,9 @@
+{
+  "success": true,
+  "item": [
+    {
+      "total": 3
+    }
+  ],
+  "error": null
+}

--- a/public/daseul/requests0.json
+++ b/public/daseul/requests0.json
@@ -1,0 +1,106 @@
+{
+  "success": true,
+  "item": [
+    {
+      "id": 1,
+      "username": "최승철",
+      "phone": "01011111111",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "응급의학과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 2,
+      "username": "권진영",
+      "phone": "01022222222",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정형외과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 3,
+      "username": "김준완",
+      "phone": "01033333333",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "응급의학과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 4,
+      "username": "박건욱",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "응급의학과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 5,
+      "username": "김민규",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "내과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 6,
+      "username": "이지훈",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "신경과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 7,
+      "username": "이경한",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정형외과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 8,
+      "username": "서준호",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "산부인과",
+      "level": "RESIDENT",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 9,
+      "username": "이진욱",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "영상의학과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 10,
+      "username": "박한빈",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "이비인후과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    }
+  ],
+  "error": null
+}

--- a/public/daseul/requests1.json
+++ b/public/daseul/requests1.json
@@ -1,0 +1,106 @@
+{
+  "success": true,
+  "item": [
+    {
+      "id": 1,
+      "username": "한유진",
+      "phone": "01011111111",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "응급의학과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 2,
+      "username": "이원우",
+      "phone": "01022222222",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "응급의학과",
+      "level": "RESIDENT",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 3,
+      "username": "장준수",
+      "phone": "01033333333",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "영상의학과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 4,
+      "username": "박철수",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "신경과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 5,
+      "username": "김규빈",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정신건강의학과",
+      "level": "RESIDENT",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 6,
+      "username": "이찬",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "영상의학과",
+      "level": "RESIDENT",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 7,
+      "username": "이준호",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "내과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 8,
+      "username": "장세용",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "성형외과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 9,
+      "username": "최한결",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "피부과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 10,
+      "username": "동새벽",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정신건강의학과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    }
+  ],
+  "error": null
+}

--- a/public/daseul/requests2.json
+++ b/public/daseul/requests2.json
@@ -1,0 +1,106 @@
+{
+  "success": true,
+  "item": [
+    {
+      "id": 1,
+      "username": "김가가",
+      "phone": "01011111111",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "영상의학과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 2,
+      "username": "김나나",
+      "phone": "01022222222",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정형외과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 3,
+      "username": "김다다",
+      "phone": "01033333333",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "응급의학과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 4,
+      "username": "김라라",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정형외과",
+      "level": "RESIDENT",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 5,
+      "username": "김마마",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "이비인후과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 6,
+      "username": "김바바",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "성형외과",
+      "level": "RESIDENT",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 7,
+      "username": "김사사",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "내과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 8,
+      "username": "김아아",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "외과",
+      "level": "FELLOW",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 9,
+      "username": "김자자",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "정신건강의학과",
+      "level": "INTERN",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    },
+    {
+      "id": 10,
+      "username": "김차차",
+      "phone": "01044444444",
+      "hospitalName": "연세 세브란스 병원",
+      "deptName": "피부과",
+      "level": "PK",
+      "auth": "USER",
+      "status": "NOTAPPROVED"
+    }
+  ],
+  "error": null
+}

--- a/src/components/BoardContainer.tsx
+++ b/src/components/BoardContainer.tsx
@@ -1,0 +1,72 @@
+import { styled } from 'styled-components';
+import { ReactNode } from 'react';
+
+const BoardContainer = ({
+  title,
+  headers,
+  children,
+}: {
+  title: string;
+  headers: { name: string; width: number }[];
+  children: ReactNode;
+}) => {
+  return (
+    <Container>
+      <Title>{title}</Title>
+      <BoardBackground>
+        <BoardHeader>
+          {headers.map((header, index) => (
+            <HeaderItem $hwidth={header.width} key={index}>
+              {header.name}
+            </HeaderItem>
+          ))}
+        </BoardHeader>
+        <BoardList>{children}</BoardList>
+      </BoardBackground>
+    </Container>
+  );
+};
+
+export default BoardContainer;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+`;
+
+const Title = styled.span`
+  font-size: 1.125rem;
+  font-weight: 700;
+`;
+
+const BoardBackground = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: ${props => props.theme.white};
+`;
+
+const BoardHeader = styled.div`
+  width: 100%;
+  height: 50px;
+  display: flex;
+  border-bottom: 1px solid ${props => props.theme.gray};
+`;
+
+const HeaderItem = styled.div<{ $hwidth: number }>`
+  display: flex;
+  flex-grow: ${props => props.$hwidth};
+  justify-content: center;
+  align-items: center;
+  flex-basis: 0;
+`;
+
+const BoardList = styled.div`
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/Pagenation.tsx
+++ b/src/components/Pagenation.tsx
@@ -1,0 +1,77 @@
+import { styled } from 'styled-components';
+
+interface PagenationProps {
+  totalItems: number;
+  currentPage: number;
+  onPageChange: (pageNumber: number) => void;
+}
+
+const Pagenation: React.FC<PagenationProps> = ({ totalItems, currentPage, onPageChange }) => {
+  const handleClickPage = (pageNumber: number) => {
+    onPageChange(pageNumber);
+  };
+
+  const goToPrevPage = () => {
+    if (currentPage > 1) {
+      handleClickPage(currentPage - 1);
+    }
+  };
+
+  const goToNextPage = () => {
+    if (currentPage < totalItems) {
+      handleClickPage(currentPage + 1);
+    }
+  };
+
+  const renderPageNumbers = () => {
+    const pageNumbers = [];
+    for (let i = 1; i <= totalItems; i++) {
+      pageNumbers.push(
+        <PageNumber key={i} onClick={() => handleClickPage(i)} className={currentPage === i ? 'active' : ''}>
+          {i}
+        </PageNumber>,
+      );
+    }
+    return pageNumbers;
+  };
+
+  return (
+    <Container>
+      <button onClick={goToPrevPage} disabled={currentPage === 1}>
+        &lt;
+      </button>
+      {renderPageNumbers()}
+      <button onClick={goToNextPage} disabled={currentPage === totalItems}>
+        &gt;
+      </button>
+    </Container>
+  );
+};
+
+export default Pagenation;
+
+const Container = styled.div`
+  width: 100%;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  button {
+    border: none;
+    outline: none;
+    background-color: transparent;
+    font-size: 1.125rem;
+    color: ${props => props.theme.primary};
+  }
+`;
+
+const PageNumber = styled.span`
+  color: ${props => props.theme.gray};
+  cursor: pointer;
+  font-size: 1.125rem;
+  &.active {
+    color: ${props => props.theme.primary};
+    font-weight: 700;
+  }
+`;

--- a/src/components/requests/RequestsItem.tsx
+++ b/src/components/requests/RequestsItem.tsx
@@ -1,0 +1,86 @@
+import { styled } from 'styled-components';
+
+interface Request {
+  id: number;
+  username: string;
+  phone: string;
+  hospitalName: string;
+  deptName: string;
+  level: string;
+  auth: string;
+  status: string;
+}
+
+const RequestsItem = ({ requests, currentPage }: { requests: Request[]; currentPage: number }) => {
+  const handleClickApprove = (id: number) => {
+    console.log(id);
+  };
+
+  const startIndex = (currentPage - 1) * 10;
+
+  return (
+    <Container>
+      {requests.map((item, index) => (
+        <RequestItem key={item.id}>
+          <span className="index">{startIndex + index + 1}</span>
+          <span className="name">{item.username}</span>
+          <span className="dept">{item.deptName}</span>
+          <span className="level">{item.level}</span>
+          <span className="phone">{item.phone}</span>
+          <span className="button">
+            <ApproveButton onClick={() => handleClickApprove(item.id)}>승인</ApproveButton>
+          </span>
+        </RequestItem>
+      ))}
+    </Container>
+  );
+};
+
+export default RequestsItem;
+
+const Container = styled.div`
+  width: 100%;
+  height: calc(100% / 10);
+  box-sizing: border-box;
+`;
+
+const RequestItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  span {
+    text-align: center;
+    flex-basis: 0;
+    color: ${props => props.theme.black};
+  }
+  .index {
+    flex-grow: 0.5;
+  }
+  .name {
+    flex-grow: 1;
+  }
+  .dept {
+    flex-grow: 1;
+  }
+  .level {
+    flex-grow: 1;
+  }
+  .phone {
+    flex-grow: 1.5;
+  }
+  .button {
+    flex-grow: 1;
+  }
+`;
+
+const ApproveButton = styled.button`
+  width: 50px;
+  height: 25px;
+  border: none;
+  outline: none;
+  border-radius: 8px;
+  background-color: ${props => props.theme.primary};
+  color: ${props => props.theme.white};
+`;

--- a/src/pages/Requests.tsx
+++ b/src/pages/Requests.tsx
@@ -1,5 +1,75 @@
+import BoardContainer from '@/components/BoardContainer';
+import RequestsItem from '@/components/requests/RequestsItem';
+import Pagenation from '@/components/Pagenation';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { styled } from 'styled-components';
+
+const header = [
+  { name: 'No', width: 0.5 },
+  { name: '이름', width: 1 },
+  { name: '부서', width: 1 },
+  { name: '직급', width: 1 },
+  { name: '연락처', width: 1.5 },
+  { name: '승인 처리', width: 1 },
+];
+
 const Requests = () => {
-  return <div>Requests</div>;
+  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 상태 관리
+
+  const handlePageChange = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
+    getList(pageNumber);
+  };
+
+  const [requests, setRequests] = useState([]);
+  const [allLength, setallLength] = useState(0);
+
+  const getLength = async () => {
+    try {
+      const data = await axios.get('http://127.0.0.1:5173/daseul/requests.json');
+      setallLength(data.data.item[0].total);
+      return data;
+    } catch (error) {
+      console.warn(error);
+      console.warn('fail');
+      return false;
+    }
+  };
+  const getList = async (page: number) => {
+    try {
+      const data = await axios.get(`http://127.0.0.1:5173/daseul/requests${page - 1}.json`);
+      setRequests(data.data.item);
+      return data;
+    } catch (error) {
+      console.warn(error);
+      console.warn('fail');
+      return false;
+    }
+  };
+  useEffect(() => {
+    getLength();
+    getList(1);
+  }, []);
+
+  return (
+    <Container>
+      <BoardContainer title="회원 가입 요청" headers={header}>
+        <RequestsItem requests={requests} currentPage={currentPage} />
+      </BoardContainer>
+      <Pagenation totalItems={allLength} currentPage={currentPage} onPageChange={handlePageChange} />
+    </Container>
+  );
 };
 
 export default Requests;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  height: 100%;
+  padding: 20px 30px;
+  box-sizing: border-box;
+`;


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

회원가입요청 페이지 레이아웃 구성
컴포넌트 동작 구현 
임시 데이터(json) 연결 

<br />

## 코드 참고사항

페이지 안에 
게시판 컨테이너 - 안에 리스트 아이템 컴포넌트 개별적으로 생성 후 삽입, children으로 받음 
페이지 네이션 게시판 컨테이너와 동등레벨에 배치 
데이터 요청은 페이지에서 수행 -> 게시판 row와 페지이네이션에 내려줌 
header 객체배열로 게시판 출력 항목과 flex-grow 너비 가지고 게시판컴포넌트에 내려주면 너비에 따라 배치되도록 구성 
=> 전체에서 재사용 가능한지는 실제 api 요청하면서 테스트 필요  
