### PR TITLE
:bug: Fix: admin 정보 리코일 연결 후 수정

### DIFF
--- a/src/components/MainHeader.tsx
+++ b/src/components/MainHeader.tsx
@@ -1,27 +1,11 @@
 import { hospitalDecode } from '@/utils/decode';
 import { MdOutlineLocalHospital } from 'react-icons/md';
 import styled from 'styled-components';
-import { useEffect, useState } from 'react';
-import { getMyPage } from '@/lib/api';
-import { UserData } from '@/lib/types';
+import { useRecoilValue } from 'recoil';
+import { AdminState } from '@/states/stateAdmin';
 
 const MainHeader = () => {
-  const [adminData, setAdminData] = useState<UserData>();
-
-  // 관리자 정보 조회
-  const getAdminInfo = async () => {
-    await getMyPage()
-      .then(res => {
-        if (res.success) {
-          setAdminData(res.item);
-        }
-      })
-      .catch(error => console.log(error));
-  };
-
-  useEffect(() => {
-    getAdminInfo();
-  }, []);
+  const adminData = useRecoilValue(AdminState);
 
   return (
     <Container>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,10 +5,13 @@ import SignUpValidation from '@/lib/Validation/validation';
 import { useForm } from 'react-hook-form';
 import { FiAlertCircle } from 'react-icons/fi';
 import { useEffect, useState } from 'react';
-import { login } from '@/lib/api';
+import { getMyPage, login } from '@/lib/api';
 import { LoginBody } from '@/lib/types';
+import { useSetRecoilState } from 'recoil';
+import { AdminState } from '@/states/stateAdmin';
 
 const Login = () => {
+  const setAdminData = useSetRecoilState(AdminState);
   const [loginError, setLoginError] = useState('');
   const navigate = useNavigate();
 
@@ -20,6 +23,16 @@ const Login = () => {
     localStorage.getItem('authToken') && navigate('/duty');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const getAdminInfo = async () => {
+    const res = await getMyPage();
+    try {
+      console.log(res);
+      setAdminData(res.item);
+    } catch {
+      console.log('관리자 정보 조회 실패');
+    }
+  };
 
   const {
     register,
@@ -45,6 +58,7 @@ const Login = () => {
           setLoginError('');
           const token = response.headers.authorization;
           saveTokenToLocalstorage(token);
+          getAdminInfo();
           navigate('/duty');
         } else {
           setLoginError('로그인에 실패하셨습니다.');

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { dutyRegist, getMyPage, hospitalDoctorList } from '@/lib/api';
-import { UserData, DoctorList } from '@/lib/types';
+import { dutyRegist, hospitalDoctorList } from '@/lib/api';
+import { DoctorList } from '@/lib/types';
 import { hname, getLevel } from '@/utils/decode';
 import Btn from '@/components/Buttons/Btn';
 import { FiAlertCircle } from 'react-icons/fi';
+import { useRecoilValue } from 'recoil';
+import { AdminState } from '@/states/stateAdmin';
 // import { Calendar } from '@/components/register';
 
 interface RegisterFormBody {
@@ -16,54 +18,28 @@ interface RegisterFormBody {
 
 const Register = () => {
   const [errorMessage, setErrorMessage] = useState('');
-  const [adminData, setAdminData] = useState<UserData>({
-    id: 0,
-    empNo: 0,
-    name: '',
-    email: '',
-    phone: '',
-    hospitalId: 0,
-    deptId: 0,
-    level: '',
-    auth: '',
-    status: '',
-    annual: 0,
-    duty: 0,
-    profileImageUrl: '',
-    hiredate: '',
-    createdAt: '',
-    updatedAt: '',
-  });
+  const adminData = useRecoilValue(AdminState);
   const [doctorList, setDoctorList] = useState<DoctorList[]>();
   const { register, handleSubmit } = useForm<RegisterFormBody>();
 
-  // 관리자 정보 조회
-  const getAdminInfo = async () => {
-    await getMyPage()
-      .then(res => {
-        console.log(res);
-        if (res.success) {
-          setAdminData(res.item);
-        }
-        console.log(adminData);
-      })
-      .catch(error => console.log(error));
-  };
-
   // 의사 목록 호출
   const hospitalDoctors = async () => {
-    const res = await hospitalDoctorList(adminData.hospitalId);
-    setDoctorList(res.item);
+    console.log(adminData.hospitalId);
+    try {
+      const res = await hospitalDoctorList(adminData.hospitalId);
+      console.log('Doctor list response:', res); // 확인용 로그
+      setDoctorList(res.item);
+    } catch (error) {
+      console.error('Error while fetching doctor list:', error);
+    }
   };
-
   useEffect(() => {
-    getAdminInfo();
+    console.log('여기', adminData);
+
     hospitalDoctors();
   }, []);
 
   const onSubmit = async (data: RegisterFormBody) => {
-    console.log(data);
-    console.log('서브미잇', data.userId, data.chooseDate);
     const body = {
       chooseDate: data.chooseDate,
     };
@@ -81,13 +57,8 @@ const Register = () => {
       <RegisterWrap onSubmit={handleSubmit(onSubmit)}>
         <RegisterForm>
           <Label>
-            <span>병원 선택</span>
-            <select defaultValue="default" {...register('hospitalId')}>
-              <option value="default" disabled hidden>
-                병원을 선택해 주세요.
-              </option>
-              <option value={adminData?.hospitalId}>{hname[adminData.hospitalId]}</option>
-            </select>
+            <span>병원 이름</span>
+            <input value={hname[adminData.hospitalId]} readOnly {...register('hospitalId')} />
           </Label>
           <Label>
             <span>당직 대상 선택</span>
@@ -179,15 +150,9 @@ const DoctorListContainer = styled.div`
   input {
     display: none;
     &:checked + .radioWrap {
-      .text {
-        color: ${props => props.theme.primay};
-      }
       font-weight: 700;
     }
     &:hover + .radioWrap {
-      .text {
-        color: ${props => props.theme.primay};
-      }
       font-weight: 700;
     }
   }
@@ -200,7 +165,7 @@ const RadioWrap = styled.div`
   cursor: pointer;
   text-align: center;
   .box1 {
-    flex: 1;
+    flex: 1.5;
   }
   .box2 {
     flex: 1;

--- a/src/states/stateAdmin.ts
+++ b/src/states/stateAdmin.ts
@@ -1,0 +1,27 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+export const AdminState = atom({
+  key: 'AdminState',
+  default: {
+    id: 0,
+    empNo: 0,
+    name: '',
+    email: '',
+    phone: '',
+    hospitalId: 0,
+    deptId: 0,
+    level: '',
+    auth: '',
+    status: '',
+    annual: 0,
+    duty: 0,
+    profileImageUrl: '',
+    hiredate: '',
+    createdAt: '',
+    updatedAt: '',
+  },
+  effects_UNSTABLE: [persistAtom],
+});


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [x] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

어드민 정보를 recoil에 저장하고, 불러와 사용합니다.

<br />

## 변경사항

1. `Login.tsx`
로그인 성공시 admin 정보를 Recoil에 저장하고, persist를 사용하여 local token과 같이 저장하여 전역으로 사용합니다.

3. `mainHeader.tsx`
메인 헤더에서 병원 이름을 불러 올 때 api 사용 대신 Recoil state를 조회하여 사용합니다.

4. `register.tsx`
랜딩시 admin 정보 호출 대신 Recoil state를 조회하여 사용합니다.
병원 선택 대신 admin 정보값에 있는 병원 명을 띄워주고, 그에 맞는 리스트를 출력합니다.

<br />
