### PR TITLE
✨ Feat: 관리자 근무 관리 페이지 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/components/Buttons/ApplyBtn.tsx
+++ b/src/components/Buttons/ApplyBtn.tsx
@@ -1,25 +1,27 @@
+import { BUTTON_TEXTS } from '@/constants/buttons';
+import { MESSAGE_TEXTS } from '@/constants/message';
 import { schedule } from '@/lib/api';
 import styled from 'styled-components';
 
 const ApplyBtn = ({ scheduleId }: { scheduleId: number }) => {
   // 연차/당직 승인
   const approveDuty = async (scheduleId: number) => {
-    if (confirm('승인 처리 하시겠습니까?')) {
+    if (confirm(MESSAGE_TEXTS.approveConfirm)) {
       const body = {
         evaluation: 'APPROVED',
       };
       await schedule(scheduleId, body)
         .then(res => {
           if (res.success) {
-            alert('승인 처리가 완료되었습니다.');
+            alert(MESSAGE_TEXTS.approveSuccess);
             location.reload();
           }
         })
-        .catch(error => console.error('당직 승인 실패', error));
+        .catch(error => console.error(MESSAGE_TEXTS.approveError, error));
     }
   };
 
-  return <Container onClick={() => approveDuty(scheduleId)}>승인</Container>;
+  return <Container onClick={() => approveDuty(scheduleId)}>{BUTTON_TEXTS.approve}</Container>;
 };
 
 export default ApplyBtn;

--- a/src/components/Buttons/RejectBtn.tsx
+++ b/src/components/Buttons/RejectBtn.tsx
@@ -1,25 +1,27 @@
+import { BUTTON_TEXTS } from '@/constants/buttons';
+import { MESSAGE_TEXTS } from '@/constants/message';
 import { schedule } from '@/lib/api';
 import styled from 'styled-components';
 
 const RejectBtn = ({ scheduleId }: { scheduleId: number }) => {
   // 연차/당직 반려
   const rejectDuty = async (scheduleId: number) => {
-    if (confirm('반려 처리 하시겠습니까?')) {
+    if (confirm(MESSAGE_TEXTS.rejectConfirm)) {
       const body = {
         evaluation: 'REJECTED',
       };
       await schedule(scheduleId, body)
         .then(res => {
           if (res.success) {
-            alert('반려 처리가 완료되었습니다.');
+            alert(MESSAGE_TEXTS.rejectSuccess);
             location.reload();
           }
         })
-        .catch(error => console.error('당직 반려 실패', error));
+        .catch(error => console.error(MESSAGE_TEXTS.rejectError, error));
     }
   };
 
-  return <Container onClick={() => rejectDuty(scheduleId)}>반려</Container>;
+  return <Container onClick={() => rejectDuty(scheduleId)}>{BUTTON_TEXTS.reject}</Container>;
 };
 
 export default RejectBtn;

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -1,14 +1,8 @@
-import {
-  BsPersonFillGear,
-  BsCalendarPlus,
-  BsCalendarWeek,
-  BsFillPersonPlusFill,
-  BsCalendarHeart,
-  BsClockHistory,
-} from 'react-icons/bs';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { logout } from '@/lib/api';
+import { BUTTON_TEXTS } from '@/constants/buttons';
+import { SIDE_BAR_OPTIONS, SIDE_BAR_TEXT } from '@/constants/sideBar';
 
 const SideBar = () => {
   const navigate = useNavigate();
@@ -23,36 +17,19 @@ const SideBar = () => {
     <Container>
       <Logo to="/duty" />
       <Menu>
-        <MenuItem to="/duty">
-          <BsCalendarWeek />
-          <span>당직 변경 관리</span>
-        </MenuItem>
-        <MenuItem to="/register">
-          <BsCalendarPlus />
-          <span>당직 일정 추가</span>
-        </MenuItem>
-        <MenuItem to="/annual">
-          <BsCalendarHeart />
-          <span>연차 신청 관리</span>
-        </MenuItem>
-        <MenuItem to="/users">
-          <BsPersonFillGear />
-          <span>사용자 관리</span>
-        </MenuItem>
-        <MenuItem to="/requests">
-          <BsFillPersonPlusFill />
-          <span>회원 가입 요청</span>
-        </MenuItem>
-        <MenuItem to="/attendance">
-          <BsClockHistory />
-          <span>근무 관리</span>
-        </MenuItem>
+        {SIDE_BAR_OPTIONS.map((item, index) => (
+          <MenuItem to={item.to} key={index}>
+            <item.icon />
+            <span>{item.text}</span>
+          </MenuItem>
+        ))}
       </Menu>
       <AdminLogo>
-        ADMIN<span>관리자</span>
+        {SIDE_BAR_TEXT.logoFront}
+        <span>{SIDE_BAR_TEXT.logoBack}</span>
       </AdminLogo>
-      <LogoutBtn onClick={handleClickLogout}>로그아웃</LogoutBtn>
-      <Mark>©Dr.Cal</Mark>
+      <LogoutBtn onClick={handleClickLogout}>{BUTTON_TEXTS.logout}</LogoutBtn>
+      <Mark>{SIDE_BAR_TEXT.mark}</Mark>
     </Container>
   );
 };

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -4,6 +4,7 @@ import {
   BsCalendarWeek,
   BsFillPersonPlusFill,
   BsCalendarHeart,
+  BsClockHistory,
 } from 'react-icons/bs';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -41,6 +42,10 @@ const SideBar = () => {
         <MenuItem to="/requests">
           <BsFillPersonPlusFill />
           <span>회원 가입 요청</span>
+        </MenuItem>
+        <MenuItem to="/attendance">
+          <BsClockHistory />
+          <span>근무 관리</span>
         </MenuItem>
       </Menu>
       <AdminLogo>

--- a/src/components/calendar/AnnualModal.tsx
+++ b/src/components/calendar/AnnualModal.tsx
@@ -3,6 +3,8 @@ import { getAnnual } from '@/lib/api';
 import { styled } from 'styled-components';
 import { getLevel, getPhone } from '@/utils/decode';
 import { AnnualData } from '@/lib/types';
+import { TABLE_HEADER_TEXTS } from '@/constants/table';
+import { MODAL_TEXTS } from '@/constants/modal';
 
 const AnnualModal = ({ date }: { date: string }) => {
   const [annual, setAnnual] = useState<AnnualData[]>([]);
@@ -12,19 +14,19 @@ const AnnualModal = ({ date }: { date: string }) => {
       const data = await getAnnual(date);
       setAnnual(data.item);
     })();
-  }, []);
+  }, [date]);
 
   return (
     <Container>
-      <Title>금일 휴가 인원</Title>
+      <Title>{MODAL_TEXTS.annualModalTitle}</Title>
       <DateWrap>{date}</DateWrap>
       <TableContainer>
         <DataWrap className="header">
-          <div>No.</div>
-          <div>이름</div>
-          <div>파트</div>
-          <div>직급</div>
-          <div className="phone">연락처</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderIndex}</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderName}</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderDept}</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderLevel}</div>
+          <div className="phone">{TABLE_HEADER_TEXTS.tableHeaderPhone}</div>
         </DataWrap>
         <Users>
           {annual.map((item, index) => (

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import { getCalendar } from '@/lib/api';
 import { Schedule } from '@/lib/types';
 import CalendarBody from '@/components/calendar/CalendarBody';
+import { BUTTON_TEXTS } from '@/constants/buttons';
 
 const Calendar = () => {
   const [scheduleData, setScheduleData] = useState<Schedule[]>();
@@ -42,7 +43,7 @@ const Calendar = () => {
           </button>
         </CalendarButtons>
         <button className="today-button" onClick={handleClickToday} disabled={!scheduleData}>
-          오늘
+          {BUTTON_TEXTS.calendarToday}
         </button>
         <MonthWrapper>{currentMonth.format('YYYY년 M월')}</MonthWrapper>
       </Header>

--- a/src/components/calendar/DutyModal.tsx
+++ b/src/components/calendar/DutyModal.tsx
@@ -3,6 +3,9 @@ import { getDuty, deleteDuty } from '@/lib/api';
 import { styled } from 'styled-components';
 import { getLevel, getPhone } from '@/utils/decode';
 import { DutyData } from '@/lib/types';
+import { MODAL_TEXTS } from '@/constants/modal';
+import { TABLE_HEADER_TEXTS } from '@/constants/table';
+import { BUTTON_TEXTS } from '@/constants/buttons';
 
 const DutyDataInitial = {
   deptName: '',
@@ -34,14 +37,14 @@ const DutyModal = ({ date, onClose }: { date: string; onClose: () => void }) => 
 
   return (
     <Container>
-      <Title>금일 당직 인원</Title>
+      <Title>{MODAL_TEXTS.dutyModalTitle}</Title>
       <DateWrap>{date}</DateWrap>
       <TableContainer>
         <DataWrap>
-          <div>이름</div>
-          <div>파트</div>
-          <div>직급</div>
-          <div>연락처</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderName}</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderDept}</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderLevel}</div>
+          <div>{TABLE_HEADER_TEXTS.tableHeaderPhone}</div>
         </DataWrap>
         <DataWrap>
           <div>{duty.username}</div>
@@ -49,7 +52,7 @@ const DutyModal = ({ date, onClose }: { date: string; onClose: () => void }) => 
           <div>{getLevel(duty.level)}</div>
           <div>{getPhone(duty.phone)}</div>
         </DataWrap>
-        <DeleteButton onClick={handleClickDelete}>당직 삭제</DeleteButton>
+        <DeleteButton onClick={handleClickDelete}>{BUTTON_TEXTS.dutyDelete}</DeleteButton>
       </TableContainer>
     </Container>
   );

--- a/src/components/duty/DutyRequestsItem.tsx
+++ b/src/components/duty/DutyRequestsItem.tsx
@@ -3,7 +3,7 @@ import ApplyBtn from '@/components/Buttons/ApplyBtn';
 import RejectBtn from '@/components/Buttons/RejectBtn';
 import { DutyRequest } from '@/lib/types';
 import { getCategory, getLevel } from '@/utils/decode';
-
+import { MESSAGE_TEXTS } from '@/constants/message';
 const DutyRequestsItem = ({ requests, currentPage }: { requests: DutyRequest[]; currentPage: number }) => {
   const startIndex = (currentPage - 1) * 10;
 
@@ -24,7 +24,7 @@ const DutyRequestsItem = ({ requests, currentPage }: { requests: DutyRequest[]; 
                 <RejectBtn scheduleId={item.scheduleId} />
               </>
             ) : (
-              <div className="done">처리 완료</div>
+              <div className="done">{MESSAGE_TEXTS.dutyRequestDone}</div>
             )}
           </div>
         </RequestItem>

--- a/src/components/requests/RequestsItem.tsx
+++ b/src/components/requests/RequestsItem.tsx
@@ -2,6 +2,8 @@ import { styled } from 'styled-components';
 import { registerApprove } from '@/lib/api';
 import { getLevel, getPhone } from '@/utils/decode';
 import { Request } from '@/lib/types';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { BUTTON_TEXTS } from '@/constants/buttons';
 
 const RequestsItem = ({ requests, currentPage }: { requests: Request[]; currentPage: number }) => {
   const approve = async (userid: number) => {
@@ -10,7 +12,7 @@ const RequestsItem = ({ requests, currentPage }: { requests: Request[]; currentP
 
   const handleClickApprove = (name: string, dept: string, id: number) => {
     approve(id);
-    alert(`${dept} ${name} 가입 승인 완료`);
+    alert(`${dept} ${name} ${MESSAGE_TEXTS.requestSuccess}`);
     window.location.reload();
   };
 
@@ -27,7 +29,7 @@ const RequestsItem = ({ requests, currentPage }: { requests: Request[]; currentP
           <span className="phone">{getPhone(item.phone)}</span>
           <span className="button">
             <ApproveButton onClick={() => handleClickApprove(item.username, item.deptName, item.id)}>
-              승인
+              {BUTTON_TEXTS.approve}
             </ApproveButton>
           </span>
         </RequestItem>

--- a/src/components/users/UsersItem.tsx
+++ b/src/components/users/UsersItem.tsx
@@ -2,15 +2,17 @@ import { styled } from 'styled-components';
 import { userRetire } from '@/lib/api';
 import { getLevel, getAuth, getPhone } from '@/utils/decode';
 import { Users } from '@/lib/types';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { USER_SELECT_OPTION } from '@/constants/select';
 
 const UsersItem = ({ userList, currentPage }: { userList: Users[]; currentPage: number }) => {
   const handleChangeState = async (dept: string, name: string, userid: number) => {
     const data = await userRetire(userid);
     if (data.response && data.response.status === 400) {
-      alert('재직 중인 사용자만 변경 가능합니다.');
+      alert(MESSAGE_TEXTS.userChangeError);
       window.location.reload();
     } else {
-      alert(`${dept} ${name} 재직 상태 변경 완료`);
+      alert(`${dept} ${name} ${MESSAGE_TEXTS.userChangeSuccess}`);
       window.location.reload();
     }
   };
@@ -29,8 +31,9 @@ const UsersItem = ({ userList, currentPage }: { userList: Users[]; currentPage: 
           <span className="auth">{getAuth(item.auth)}</span>
           <div className="state">
             <select value={item.status} onChange={() => handleChangeState(item.deptName, item.username, item.id)}>
-              <option value="APPROVED">재직중</option>
-              <option value="RETIRED">퇴사</option>
+              {USER_SELECT_OPTION.map(option => (
+                <option value={option.value}>{option.text}</option>
+              ))}
             </select>
           </div>
         </UserItem>

--- a/src/constants/buttons.ts
+++ b/src/constants/buttons.ts
@@ -1,0 +1,9 @@
+export const BUTTON_TEXTS = Object.freeze({
+  approve: '승인',
+  reject: '반려',
+  login: '로그인',
+  logout: '로그아웃',
+  calendarToday: '오늘',
+  register: '등록하기',
+  dutyDelete: '당직 삭제',
+});

--- a/src/constants/login.ts
+++ b/src/constants/login.ts
@@ -1,0 +1,8 @@
+export const LOGIN_TEXTS = Object.freeze({
+  title: `대학병원 의사들을 위한\n쉽고 빠른 연차 당직 관리 서비스`,
+  hello: '어서오세요!',
+  emailPlacehoder: '이메일을 입력해 주세요.',
+  passwordPlacehoder: '비밀번호를 입력해 주세요.',
+  emailInputTitle: 'email',
+  passwordInputTitle: 'password',
+});

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,28 @@
+export const MESSAGE_TEXTS = Object.freeze({
+  // 공통승인
+  approveConfirm: '승인 처리 하시겠습니까?',
+  approveSuccess: '승인 처리가 완료되었습니다.',
+  approveError: '승인 실패',
+  // 공통반려
+  rejectConfirm: '반려 처리 하시겠습니까?',
+  rejectSuccess: '반려 처리가 완료되었습니다.',
+  rejectError: '반려 실패',
+  // 공통요청
+  listEmpty: '요청 목록이 존재하지 않습니다.',
+  // duty
+  dutyRequestDone: '처리완료',
+  dutyAddError: '당직 일정 등록에 실패하셨습니다.',
+  // request
+  requestSuccess: '가입 승인이 완료되었습니다.',
+  // user
+  userChangeSuccess: '재직 상태 변경이 완료되었습니다.',
+  userChangeError: '재직 중인 사용자만 변경 가능합니다.',
+  userListEmpty: '사용자 목록이 존재하지 않습니다.',
+  // login
+  loginError: '로그인에 실패하셨습니다.',
+  loginConsoleError: '로그인 실패',
+  // getAdminInfo
+  getAdminInfoConsoleError: '관리자 정보 조회 실패',
+  // getDutyDoctorList
+  getDoctorListConsoleError: '의사 목록 조회 실패',
+});

--- a/src/constants/modal.ts
+++ b/src/constants/modal.ts
@@ -1,0 +1,4 @@
+export const MODAL_TEXTS = Object.freeze({
+  dutyModalTitle: '금일 당직 인원',
+  annualModalTitle: '금일 휴가 인원',
+});

--- a/src/constants/pageTitle.ts
+++ b/src/constants/pageTitle.ts
@@ -1,0 +1,7 @@
+export const PAGE_TITLE_TEXTS = Object.freeze({
+  annualTitle: '연차 신청 관리',
+  dutyTitle: '당직 변경 관리',
+  requestTitle: '회원 가입 요청',
+  usersTitle: '사용자 관리',
+  attendanceTitle: '근무 관리',
+});

--- a/src/constants/register.ts
+++ b/src/constants/register.ts
@@ -1,0 +1,5 @@
+export const REGISTER_TEXTS = Object.freeze({
+  hospitalName: '병원 이름',
+  selectDutyTarget: '당직 대상 선택',
+  selectDate: '날짜 지정',
+});

--- a/src/constants/select.ts
+++ b/src/constants/select.ts
@@ -1,0 +1,4 @@
+export const USER_SELECT_OPTION = [
+  { value: 'APPROVED', text: '재직중' },
+  { value: 'RETIRED', text: '퇴사' },
+];

--- a/src/constants/sideBar.ts
+++ b/src/constants/sideBar.ts
@@ -1,0 +1,29 @@
+import {
+  BsPersonFillGear,
+  BsCalendarPlus,
+  BsCalendarWeek,
+  BsFillPersonPlusFill,
+  BsCalendarHeart,
+  BsClockHistory,
+} from 'react-icons/bs';
+
+interface MenuItem {
+  to: string;
+  icon: React.ElementType;
+  text: string;
+}
+
+export const SIDE_BAR_OPTIONS: MenuItem[] = [
+  { to: '/duty', icon: BsCalendarWeek, text: '당직 변경 관리' },
+  { to: '/register', icon: BsCalendarPlus, text: '당직 일정 추가' },
+  { to: '/annual', icon: BsCalendarHeart, text: '연차 신청 관리' },
+  { to: '/users', icon: BsPersonFillGear, text: '사용자 관리' },
+  { to: '/requests', icon: BsFillPersonPlusFill, text: '회원 가입 요청' },
+  { to: '/attendance', icon: BsClockHistory, text: '근무 관리' },
+];
+
+export const SIDE_BAR_TEXT = {
+  logoFront: 'ADMIN',
+  logoBack: '관리자',
+  mark: '©Dr.Cal',
+};

--- a/src/constants/table.ts
+++ b/src/constants/table.ts
@@ -1,0 +1,7 @@
+export const TABLE_HEADER_TEXTS = Object.freeze({
+  tableHeaderIndex: 'No.',
+  tableHeaderName: '이름',
+  tableHeaderDept: '파트',
+  tableHeaderLevel: '직급',
+  tableHeaderPhone: '연락처',
+});

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,10 +1,8 @@
+const { VITE_BASEURL } = import.meta.env;
 import { Eveluation, LoginBody, PagesBody, dutyRegistBody } from '@/lib/types/index.ts';
 import axios from 'axios';
 
-const host =
-  window.location.hostname === 'localhost'
-    ? 'http://fastcampus-mini-project-env.eba-khrscmx7.ap-northeast-2.elasticbeanstalk.com'
-    : 'api';
+const host = window.location.hostname === 'localhost' ? VITE_BASEURL : 'api';
 
 const instance = axios.create({
   baseURL: host,
@@ -190,11 +188,7 @@ export const getCalendar = async () => {
 // 날짜별 휴가 인원 조회
 export const getAnnual = async (date: string) => {
   try {
-    const res = await instance.get(`/schedule/date?chooseDate=${date}&category=ANNUAL`, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
+    const res = await authInstance.get(`/schedule/date?chooseDate=${date}&category=ANNUAL`);
     return res.data;
   } catch (error) {
     console.error('휴가 인원 조회 실패', error);
@@ -204,11 +198,7 @@ export const getAnnual = async (date: string) => {
 // 날짜별 당직 인원 조회
 export const getDuty = async (date: string) => {
   try {
-    const res = await instance.get(`/schedule/date?chooseDate=${date}&category=DUTY`, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
+    const res = await authInstance.get(`/schedule/date?chooseDate=${date}&category=DUTY`);
     return res.data;
   } catch (error) {
     console.error('당직 인원 조회 실패', error);

--- a/src/pages/Annual.tsx
+++ b/src/pages/Annual.tsx
@@ -5,6 +5,8 @@ import { annual } from '@/lib/api';
 import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import Loading from '@/components/Loading';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { PAGE_TITLE_TEXTS } from '@/constants/pageTitle';
 
 const header = [
   { name: 'No', width: 0.5 },
@@ -60,11 +62,11 @@ const Annual = () => {
         <option value="asc">오래된순</option>
       </select>
 
-      <BoardContainer title="연차 신청 관리" headers={header}>
+      <BoardContainer title={PAGE_TITLE_TEXTS.annualTitle} headers={header}>
         {requestsData.length > 0 ? (
           <AnnualItem requests={requestsData} currentPage={currentPage} />
         ) : (
-          !isLoading && <Empty>요청 목록이 존재하지 않습니다.</Empty>
+          !isLoading && <Empty>{MESSAGE_TEXTS.listEmpty}</Empty>
         )}
       </BoardContainer>
       {requestsData.length > 0 && (

--- a/src/pages/Attendance.tsx
+++ b/src/pages/Attendance.tsx
@@ -1,9 +1,10 @@
 import { styled } from 'styled-components';
+import { PAGE_TITLE_TEXTS } from '@/constants/pageTitle';
 
 const Attendance = () => {
   return (
     <Container>
-      <PageTitle>근무관리</PageTitle>
+      <PageTitle>{PAGE_TITLE_TEXTS.attendanceTitle}</PageTitle>
     </Container>
   );
 };

--- a/src/pages/Attendance.tsx
+++ b/src/pages/Attendance.tsx
@@ -1,0 +1,33 @@
+import { styled } from 'styled-components';
+
+const Attendance = () => {
+  return (
+    <Container>
+      <PageTitle>근무관리</PageTitle>
+    </Container>
+  );
+};
+
+export default Attendance;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  height: 100%;
+  padding: 20px 80px 60px 80px;
+  box-sizing: border-box;
+  select {
+    position: absolute;
+    right: 80px;
+    width: 100px;
+    height: 30px;
+    margin-top: -5px;
+  }
+`;
+
+const PageTitle = styled.span`
+  font-size: 1.125rem;
+  font-weight: 700;
+`;

--- a/src/pages/Duty.tsx
+++ b/src/pages/Duty.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 import { duty } from '@/lib/api';
 import styled from 'styled-components';
 import Loading from '@/components/Loading';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { PAGE_TITLE_TEXTS } from '@/constants/pageTitle';
 
 const header = [
   { name: 'No', width: 0.5 },
@@ -76,7 +78,7 @@ const Duty = () => {
       setSort(savedSort);
     }
     getSortedDutyList(0, savedSort || sort);
-  }, []);
+  }, [sort]);
 
   return (
     <Container>
@@ -85,11 +87,11 @@ const Duty = () => {
         <option value="desc">최신순</option>
         <option value="asc">오래된순</option>
       </Select>
-      <BoardContainer title="당직 변경 관리" headers={header}>
+      <BoardContainer title={PAGE_TITLE_TEXTS.dutyTitle} headers={header}>
         {requests.length > 0 ? (
           <DutyRequestsItem requests={requests} currentPage={currentPage} />
         ) : (
-          !isLoading && <Empty>요청 목록이 존재하지 않습니다.</Empty>
+          !isLoading && <Empty>{MESSAGE_TEXTS.listEmpty}</Empty>
         )}
       </BoardContainer>
       {requests.length > 0 ? (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,6 +11,9 @@ import { useSetRecoilState } from 'recoil';
 import { AdminState } from '@/states/stateAdmin';
 import backgroundLogo from '/backgroundlogo.png';
 import logowhithtext from '/logowithtext.png';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { LOGIN_TEXTS } from '@/constants/login';
+import { BUTTON_TEXTS } from '@/constants/buttons';
 
 const Login = () => {
   const setAdminData = useSetRecoilState(AdminState);
@@ -29,10 +32,9 @@ const Login = () => {
   const getAdminInfo = async () => {
     const res = await getMyPage();
     try {
-      console.log(res);
       setAdminData(res.item);
     } catch {
-      console.log('관리자 정보 조회 실패');
+      console.error(MESSAGE_TEXTS.getAdminInfoConsoleError);
     }
   };
 
@@ -63,12 +65,12 @@ const Login = () => {
           await getAdminInfo();
           navigate('/duty');
         } else {
-          setLoginError('로그인에 실패하셨습니다.');
-          console.error('로그인 실패');
+          setLoginError(MESSAGE_TEXTS.loginError);
+          console.error(MESSAGE_TEXTS.loginConsoleError);
         }
       } catch (error) {
-        setLoginError('로그인에 실패하셨습니다.');
-        console.error('로그인 실패', error);
+        setLoginError(MESSAGE_TEXTS.loginError);
+        console.error(MESSAGE_TEXTS.loginConsoleError, error);
       }
     }
   };
@@ -77,17 +79,16 @@ const Login = () => {
     <Container>
       <ImgContainer1 />
       <Textwrap>
-        <span>대학병원 의사들을 위한</span>
-        <span>쉽고 빠른 연차 당직 관리 서비스</span>
+        <span>{LOGIN_TEXTS.title}</span>
       </Textwrap>
       <ImgContainer2 />
 
       <Wrap>
-        <h1>어서오세요!</h1>
+        <h1>{LOGIN_TEXTS.hello}</h1>
         <FormWrap onSubmit={handleSubmit(onSubmit)} name="loginForm">
           <InputContainer>
-            <div className="inputTitle">email</div>
-            <input type="email" placeholder="이메일을 입력해주세요." {...register('email')} />
+            <div className="inputTitle">{LOGIN_TEXTS.emailInputTitle}</div>
+            <input type="email" placeholder={LOGIN_TEXTS.emailPlacehoder} {...register('email')} />
             {errors.email && (
               <InfoBox>
                 <FiAlertCircle />
@@ -96,8 +97,8 @@ const Login = () => {
             )}
           </InputContainer>
           <InputContainer>
-            <div className="inputTitle">password</div>
-            <input type="password" placeholder="비밀번호를 입력해주세요." {...register('password')} />
+            <div className="inputTitle">{LOGIN_TEXTS.passwordInputTitle}</div>
+            <input type="password" placeholder={LOGIN_TEXTS.passwordPlacehoder} {...register('password')} />
             {errors.password && (
               <InfoBox>
                 <FiAlertCircle />
@@ -112,7 +113,7 @@ const Login = () => {
             )}
           </InputContainer>
           <InputContainer>
-            <Btn content={'로그인'} />
+            <Btn content={BUTTON_TEXTS.login} />
           </InputContainer>
         </FormWrap>
       </Wrap>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -10,6 +10,9 @@ import { useRecoilValue } from 'recoil';
 import { AdminState } from '@/states/stateAdmin';
 import Calendar from '@/components/calendar/Calendar';
 import Loading from '@/components/Loading';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { BUTTON_TEXTS } from '@/constants/buttons';
+import { REGISTER_TEXTS } from '@/constants/register';
 
 interface RegisterFormBody {
   hospitalId: number;
@@ -32,7 +35,7 @@ const Register = () => {
       setDoctorList(res.item);
     } catch (error) {
       setIsLoading(false);
-      console.error('Error while fetching doctor list:', error);
+      console.error(MESSAGE_TEXTS.getDoctorListConsoleError, error);
     } finally {
       setIsLoading(false);
     }
@@ -50,7 +53,7 @@ const Register = () => {
       await dutyRegist(data.userId, body);
       location.reload();
     } catch (error) {
-      setErrorMessage('당직 일정 등록 실패');
+      setErrorMessage(MESSAGE_TEXTS.dutyAddError);
     }
   };
 
@@ -63,11 +66,11 @@ const Register = () => {
       <RegisterWrap onSubmit={handleSubmit(onSubmit)}>
         <RegisterForm>
           <Label>
-            <span>병원 이름</span>
+            <span>{REGISTER_TEXTS.hospitalName}</span>
             <input value={hospitalDecode[adminData.hospitalId].hospital} readOnly {...register('hospitalId')} />
           </Label>
           <Label>
-            <span>당직 대상 선택</span>
+            <span>{REGISTER_TEXTS.selectDutyTarget}</span>
             <DoctorListContainer>
               {doctorList?.map(doctor => (
                 <label key={doctor.userId}>
@@ -83,7 +86,7 @@ const Register = () => {
             </DoctorListContainer>
           </Label>
           <Label>
-            날짜 지정
+            {REGISTER_TEXTS.selectDate}
             <input type="date" {...register('chooseDate')} />
           </Label>
           <div>
@@ -94,7 +97,7 @@ const Register = () => {
               </InfoBox>
             )}
           </div>
-          <Btn content={'등록하기'}></Btn>
+          <Btn content={BUTTON_TEXTS.register}></Btn>
         </RegisterForm>
       </RegisterWrap>
     </Container>

--- a/src/pages/Requests.tsx
+++ b/src/pages/Requests.tsx
@@ -5,6 +5,8 @@ import { useState, useEffect } from 'react';
 import { styled } from 'styled-components';
 import { register } from '@/lib/api';
 import Loading from '@/components/Loading';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { PAGE_TITLE_TEXTS } from '@/constants/pageTitle';
 
 const header = [
   { name: 'No', width: 0.5 },
@@ -28,7 +30,7 @@ const Requests = () => {
       setSort(savedSort);
     }
     getSortedList(0, savedSort || sort);
-  }, []);
+  }, [sort]);
 
   const getSortedList = async (page: number, selectedSort: string) => {
     try {
@@ -69,11 +71,11 @@ const Requests = () => {
         <option value="desc">최신순</option>
         <option value="asc">오래된순</option>
       </select>
-      <BoardContainer title="회원 가입 요청" headers={header}>
+      <BoardContainer title={PAGE_TITLE_TEXTS.requestTitle} headers={header}>
         {requests.length > 0 ? (
           <RequestsItem requests={requests} currentPage={currentPage} />
         ) : (
-          !isLoading && <Empty>요청 목록이 존재하지 않습니다.</Empty>
+          !isLoading && <Empty>{MESSAGE_TEXTS.listEmpty}</Empty>
         )}
       </BoardContainer>
       {requests.length > 0 ? (

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -5,6 +5,8 @@ import { useState, useEffect } from 'react';
 import { styled } from 'styled-components';
 import { users } from '@/lib/api';
 import Loading from '@/components/Loading';
+import { MESSAGE_TEXTS } from '@/constants/message';
+import { PAGE_TITLE_TEXTS } from '@/constants/pageTitle';
 
 const header = [
   { name: 'No', width: 0.5 },
@@ -29,7 +31,7 @@ const Users = () => {
       setSort(savedSort);
     }
     getSortedList(0, savedSort || sort);
-  }, []);
+  }, [sort]);
 
   const getSortedList = async (page: number, selectedSort: string) => {
     try {
@@ -69,11 +71,11 @@ const Users = () => {
         <option value="createdAt,desc">최신순</option>
         <option value="createdAt,asc">오래된순</option>
       </select>
-      <BoardContainer title="사용자 관리" headers={header}>
+      <BoardContainer title={PAGE_TITLE_TEXTS.usersTitle} headers={header}>
         {userList.length > 0 ? (
           <UsersItem userList={userList} currentPage={currentPage} />
         ) : (
-          !isLoading && <Empty>사용자 목록이 존재하지 않습니다.</Empty>
+          !isLoading && <Empty>{MESSAGE_TEXTS.userListEmpty}</Empty>
         )}
       </BoardContainer>
       {userList.length > 0 ? (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import Layout from '@/pages/Layout';
 import Annual from '@/pages/Annual';
 import Duty from '@/pages/Duty';
 import Register from '@/pages/Register';
+import Attendance from '@/pages/Attendance';
 
 const router = createBrowserRouter([
   {
@@ -38,6 +39,10 @@ const router = createBrowserRouter([
           {
             path: '/register',
             element: <Register />,
+          },
+          {
+            path: '/attendance',
+            element: <Attendance />,
           },
         ],
       },


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 업데이트
- [x] 사소한 수정

<br />

## PR 요약

근무관리 페이지 추가, 전체적인 리팩토링  

<br />

## 변경사항

1. 근무관리 페이지를 생성 후 라우터 추가, 사이드바 연동 했습니다. 
2. 사이드바의 중복된 코드를 사이드바 옵션 constants 를 추가해 map으로 개선했습니다. 
3. 변경된 url 주소를 적용했습니다.  개발시    `.env` 파일 추가후 baseurl 작성이 필요합니다. 
4. 전체 컴포넌트와 페이지의 텍스트를 상수화했습니다.  
    => 특별히 들어가는 텍스트가 많은 페이지나 컴포넌트가 아니면 공통적으로 관리할 수 있도록 message, buttons, select, table, title 로 구분하여 작성해보았습니다. 해당 구조가 적당하지 않으면 페이지 별로 다시 분리작성하겠습니다! 

게시판 테이블 관련, 정렬 select 관련 텍스트는 (부서->파트, 최신순, 오래된순)
테이블 라이브러리 적용 후 삭제될 가능성이 있어 우선 상수화 하지 않았습니다!! 
추후 라이브러리 적용하면서 작성하겠습니다! 

<br />

## 코드 참고사항

constants 파일 생성중 
` 메시지 텍스트를 더 평면적인 구조로 변경하는 것이 권장되는 접근 방법입니다. `
를 참고하여 중첩이 아닌 평면적인 구조로 작성했습니다. 

![image](https://github.com/MINI-TEAM3/admin/assets/100559990/e5e482e0-8640-4758-9137-9e7254b5cef4)

